### PR TITLE
Update Example Home Assistant Configuration.yaml

### DIFF
--- a/Example Home Assistant Configuration.yaml
+++ b/Example Home Assistant Configuration.yaml
@@ -6,7 +6,8 @@ mqtt:
   password: YOURPASSWORD
 
 light:
-  - platform: mqtt_json
+  - platform: mqtt
+    schema: json
     name: "Porch Strip"
     state_topic: "bruh/porch"
     command_topic: "bruh/porch/set"
@@ -36,7 +37,7 @@ light:
     optimistic: false
     qos: 0
 
-input_slider:
+input_number:
   porch_animation_speed:
     name: Porch Animation Speed
     initial: 150
@@ -50,7 +51,7 @@ automation:
     hide_entity: False
     trigger:
       - platform: state
-        entity_id: input_slider.porch_animation_speed
+        entity_id: input_number.porch_animation_speed
     action:
       - service: mqtt.publish
         data_template:


### PR DESCRIPTION
In the new home assistant version:
* `mqtt_json` changed to `plattform: mqtt` and `schema: json`
* `input_slider` changed to `input_number`